### PR TITLE
Reconfigure auto-builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,6 @@ jobs:
     - name: tests
       run: |
           echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status
-          chmod +x cosmosocks/*
-          cp cosmosocks/* .
+          chmod +x ${{steps.download.outputs.download-path}}/*
+          cp ${{steps.download.outputs.download-path}}/* .
           make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,11 @@ jobs:
   tests-linux:
     runs-on: ubuntu-latest
     steps:
-      - name: Download all workflow run artifacts
-        uses: actions/download-artifact@v3
-      - name: tests
-        run: |
-            echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status
-            make test
+    - name: Download all workflow run artifacts
+    - uses: actions/checkout@v3
+      uses: actions/download-artifact@v3
+
+    - name: tests
+      run: |
+          echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status
+          make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,6 @@ jobs:
     - name: tests
       run: |
           echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status
-          chmod +x ${{steps.download.outputs.download-path}}/*
-          cp ${{steps.download.outputs.download-path}}/* .
+          chmod +x cosmosocks/*
+          cp cosmosocks/* .
           make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
         if-no-files-found: error
   tests-linux:
     runs-on: ubuntu-latest
+    needs: build
     steps:
     - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,5 @@ jobs:
     - name: tests
       run: |
           echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status
-          copy cosmosocks/* .
+          cp cosmosocks/* .
           make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,8 @@ jobs:
   tests-linux:
     runs-on: ubuntu-latest
     steps:
-    - name: Download all workflow run artifacts
     - uses: actions/checkout@v3
-      uses: actions/download-artifact@v3
-
+    - uses: actions/download-artifact@v3
     - name: tests
       run: |
           echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -11,10 +10,10 @@ jobs:
     - name: make
       run: make COSMO=amalgamation-tiny
 
-    - name: tests
-      run: |
-          echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status
-          make test
+      #- name: tests
+      #run: |
+      #    echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status
+      #    make test
       
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v3.1.0
@@ -26,3 +25,12 @@ jobs:
             cosmosocks_server
             cosmosocks_server_ape
         if-no-files-found: error
+  tests-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v3
+      - name: tests
+        run: |
+            echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status
+            make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,5 @@ jobs:
     - name: tests
       run: |
           echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status
-          find
+          copy cosmosocks/* .
           make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,5 @@ jobs:
     - name: tests
       run: |
           echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status
+          find
           make test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,6 @@ jobs:
     - name: tests
       run: |
           echo 0 | sudo tee /proc/sys/fs/binfmt_misc/status
+          chmod +x cosmosocks/*
           cp cosmosocks/* .
           make test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Artifacts](https://github.com/bannsec/cosmosocks/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/bannsec/cosmosocks/actions/workflows/build.yml)
+[![Tests:Linux](https://github.com/bannsec/cosmosocks/actions/workflows/build.yml/badge.svg)](https://github.com/bannsec/cosmosocks/actions/workflows/build.yml)
 
 ![Windows](https://github.com/bannsec/cosmosocks/raw/master/icons/windows.png)
 ![Apple](https://github.com/bannsec/cosmosocks/raw/master/icons/apple.png)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Tests:Linux](https://github.com/bannsec/cosmosocks/actions/workflows/build.yml/badge.svg)](https://github.com/bannsec/cosmosocks/actions/workflows/build.yml)
+[![Build and test](https://github.com/bannsec/cosmosocks/actions/workflows/build.yml/badge.svg)](https://github.com/bannsec/cosmosocks/actions/workflows/build.yml)
 
 ![Windows](https://github.com/bannsec/cosmosocks/raw/master/icons/windows.png)
 ![Apple](https://github.com/bannsec/cosmosocks/raw/master/icons/apple.png)


### PR DESCRIPTION
Change auto-builds to separate out tests into steps. This will allow for testing different operating systems independently.